### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/1](https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/1)

The best way to fix this problem is to explicitly specify a `permissions` block at either the workflow root level or the `build` job level to set least privileges. Since the workflow does not require write access to repository contents or other resources, the minimal necessary permission is `contents: read`. To easily propagate restricted permissions to all jobs in the workflow, add the following block directly after the `name` key, before the `on` key, in `.github/workflows/go.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, definitions, or methods are necessary. The only required change is adding the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
