### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/2](https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow. The best location is at the root (top-level), so it applies by default to all jobs, unless overridden in a job. Since all the steps only require checking out code and installing/running packages, only read access to repository contents is required. No steps need permission to write to the repository, issues, or pull requests. 

Specifically:  
- Add a `permissions:` block just beneath the workflow `name:` or above/below the `on:` block.
- Set `contents: read` as the minimal required permission.

No extra imports, definitions, or dependency edits are necessary as we're only editing the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
