### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,4 +1,6 @@
 name: Python Package using Conda
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/3](https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/3)

To fix this issue, add a `permissions` key to the workflow (preferably at the root, unless individual jobs need distinct permissions). The minimal sensible default for a build/test workflow is `contents: read`, since it checks out the code but does not need to write to the repo, or access issues or pull requests. Edit `.github/workflows/python-package-conda.yml` to insert the following block directly after the `name` (before `on`), or at the top level before the jobs list. No other code changes are necessary, and this approach follows best practices without changing any functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
