### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/4](https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block at the root level of the workflow, or for the specific job, restricting permission to the least required privileges. Since the workflow only interacts with the code (checking it out and running tests and linting) but does not write to the repository, the minimum needed is `contents: read`. Place this block either above `jobs:` for the entire workflow or inside the `build` job. For best future-proofing and clarity, add `permissions: contents: read` directly after the workflow `name:` line (line 4), so all jobs inherit it and accidental privilege escalation is less likely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
