### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/5](https://github.com/santiagourdaneta/Feed-de-Posts-con-Go-Rust-y-Python/security/code-scanning/5)

To address the issue and follow least privilege security practices, you should explicitly set the job permissions so that the `GITHUB_TOKEN` has only the privileges needed to run the workflow. For the build and test steps that only check out code and run commands, minimal permissions are required. The best fix is to add a `permissions:` key with `contents: read` just above the job definition (`runs-on: ubuntu-latest`), or, if multiple jobs exist and none need elevated privileges, at the top level of the workflow after the `name:` field. Since only the build job is shown, place it at the job level (line 14 or 15), unless you want to protect all future jobs at once by putting it at the root (line 2).  
No imports or external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
